### PR TITLE
GEM、検索処理でReferencePropertyEditorの「表示ラベルとして扱うプロパティ」を考慮する（GemConfigServiceのフラグデフォルト設定）

### DIFF
--- a/src/main/resources/mtp-service-config.xml
+++ b/src/main/resources/mtp-service-config.xml
@@ -60,6 +60,9 @@
 		<!-- CSVダウンロード件数上限値 -->
 		<property name="csvDownloadMaxCount" value="65535" />
 
+		<!-- 検索処理で表示ラベルとして扱うプロパティを検索条件に利用するか -->
+		<property name="useDisplayLabelItemInSearch" value="true" />
+
 		<!-- CSVダウンロード文字コード -->
 		<!--
 		gem-service-config.xmlにUTF8が設定されています。


### PR DESCRIPTION
GemConfigServiceに追加したフラグのデフォルト設定