### PR TITLE
GEM、検索結果のCSVダウンロードでReferencePropertyEditorの「表示ラベルとして扱うプロパティ」を考慮する（GemConfigServiceのフラグデフォルト設定）

### DIFF
--- a/src/main/resources/mtp-service-config.xml
+++ b/src/main/resources/mtp-service-config.xml
@@ -63,6 +63,9 @@
 		<!-- 検索処理で表示ラベルとして扱うプロパティを検索条件に利用するか -->
 		<property name="useDisplayLabelItemInSearch" value="true" />
 
+		<!-- CSVダウンロード処理で表示ラベルとして扱うプロパティを出力するか -->
+		<property name="useDisplayLabelItemInCsvDownload" value="true" />
+
 		<!-- CSVダウンロード文字コード -->
 		<!--
 		gem-service-config.xmlにUTF8が設定されています。


### PR DESCRIPTION
GemConfigServiceに追加したフラグのデフォルト設定